### PR TITLE
Fix external URL for x86 guide in lecture 3

### DIFF
--- a/lectures/03-adder.md
+++ b/lectures/03-adder.md
@@ -783,5 +783,5 @@ Lets take our `adder` compiler out for a spin!
 
 Will iterate on this till we have a pretty kick-ass language.
 
-[evans-x86-guide]: www.cs.virginia.edu/~evans/cs216/guides/x86.html
+[evans-x86-guide]: http://www.cs.virginia.edu/~evans/cs216/guides/x86.html
 [x86-full]: http://www.felixcloutier.com/x86/


### PR DESCRIPTION
By appending http protocol in the beginning, the link actually goes to the external link. Originally, it was trying to look for the link in the same domain.

There are also other broken links, but they are mostly internal links, which I don't have an idea to do anything about.